### PR TITLE
Add math.CT proposals batch 2

### DIFF
--- a/18A30-MinimalInitialFunctorLimits.tex
+++ b/18A30-MinimalInitialFunctorLimits.tex
@@ -1,0 +1,44 @@
+\documentclass[12pt]{article}
+\usepackage{pmmeta}
+\pmcanonicalname{MinimalInitialFunctorLimits}
+\pmcreated{2026-02-28 00:25:00}
+\pmmodified{2026-02-28 00:25:00}
+\pmowner{codex}{00000}
+\pmmodifier{codex}{00000}
+\pmtitle{minimal initial functors for computing limits}
+\pmrecord{11}{999996}
+\pmprivacy{1}
+\pmauthor{codex}{00000}
+\pmtype{Topic}
+\pmclassification{msc}{18A30}
+\pmdefines{minimal initial functor}
+\pmdefines{generalized rank of a diagram}
+
+\endmetadata
+
+\usepackage{amsmath, amssymb}
+
+\begin{document}
+A classical tactic for computing limits in a category $\mathcal D$ is to restrict a diagram $G\colon Q\to \mathcal D$ along an \emph{initial functor} $F\colon P\to Q$. The restriction $G\circ F$ has the same limit as $G$, but can often be evaluated with fewer objects and morphisms. Dey--Lesnick (arXiv:2601.00209) study this technique for diagrams indexed by finite posets, emphasizing algorithmic aspects that are crucial in applied settings such as multiparameter persistence.
+
+\medskip
+\noindent\textbf{Minimal initial functors.} Fix a finite poset $Q$. An initial functor $F\colon P\to Q$ is called \emph{minimal} if $P$ has the smallest possible numbers of objects and morphisms among all sources of initial functors with codomain $Q$. The paper shows that when $Q$ is a finite poset (and in particular when it is an interval inside $\mathbb N^d$), every minimal initial functor is realized by a subposet inclusion. Moreover:
+\begin{itemize}
+  \item When $Q\subseteq \mathbb N^d$ is an interval with $n$ minimal elements and $d\le 3$, the size of $P$ is $\Theta(n)$.
+  \item For $d>3$ one needs $\Theta(n^2)$ objects in the worst case.
+  \item There are efficient algorithms that, given $Q$, construct an explicit minimal inclusion $P\hookrightarrow Q$.
+\end{itemize}
+The authors work entirely with combinatorial models, so one can track the precise cost of each restriction step.
+
+\medskip
+\noindent\textbf{Applications to limit computation.} Suppose $G\colon Q\to \mathbf{Vec}$ lands in vector spaces. Restricting along a minimal initial inclusion $F$ gives a diagram $G\circ F$ indexed by a much smaller poset while keeping the same limit. The paper bounds the number of arithmetic operations needed to compute $\lim G$ in terms of $|P|$ and the dimension vector of $G$, and refines these bounds when $Q$ is connected. They also analyze the \emph{generalized rank} of $G$, namely the rank of the canonical morphism $\lim G\to \mathrm{colim}\,G$, which is important in persistent homology; the minimality of $F$ yields asymptotically sharp complexity estimates for this computation as well.
+
+\medskip
+These results situate initial functors at the heart of constructive limit computation: not only are they a conceptual tool, but when chosen optimally they translate directly into running-time statements for multiparameter persistence algorithms.
+
+\bigskip
+\noindent\textbf{Reference.}
+\begin{itemize}
+  \item T.~K. Dey, M. Lesnick, \emph{Limit computation over posets via minimal initial functors}, arXiv:2601.00209 (2026).
+\end{itemize}
+\end{document}

--- a/18A99-TunnelGeometryProliferationLogic.tex
+++ b/18A99-TunnelGeometryProliferationLogic.tex
@@ -1,0 +1,45 @@
+\documentclass[12pt]{article}
+\usepackage{pmmeta}
+\pmcanonicalname{TunnelGeometryProliferationLogic}
+\pmcreated{2026-02-28 00:27:00}
+\pmmodified{2026-02-28 00:27:00}
+\pmowner{codex}{00000}
+\pmmodifier{codex}{00000}
+\pmtitle{tunnel geometry and proliferation logic}
+\pmrecord{11}{999996}
+\pmprivacy{1}
+\pmauthor{codex}{00000}
+\pmtype{Topic}
+\pmclassification{msc}{18A99}
+\pmdefines{tunnel geometry}
+\pmdefines{proliferation logic}
+\pmdefines{Lawvere metric equivalence}
+
+\endmetadata
+
+\usepackage{amsmath, amssymb}
+
+\begin{document}
+Some categorical frameworks attempt to encode ``locality'' without assuming an a priori space of points. Two such proposals---\emph{Tunnel Geometry} and \emph{Proliferation Logic}---were developed independently, but Sukhov (arXiv:2601.00803) shows that they are in fact two syntactic descriptions of the same structure.
+
+\medskip
+Tunnel Geometry packages ``regions'' and their refinements into a frame equipped with a Lawvere metric that records how refinement depth accumulates. Proliferation Logic, on the other hand, is phrased in proof-theoretic terms: its models track stability of inference under refinement of contexts. Both carry a canonical category of ultrafilters, and both admit Laplacian operators that measure how quickly refinement stabilizes.
+
+\medskip
+The paper proves that each theory can be interpreted as a frame $\mathcal F$ equipped with:
+\begin{itemize}
+  \item its space $\mathrm{Ult}(\mathcal F)$ of ultrafilters,
+  \item a Lawvere metric compatible with the frame operations, and
+  \item structure maps relating Laplacians to refinement paths.
+\end{itemize}
+In this common environment the author constructs explicit functors that send a tunnel space to its corresponding proliferative logic model and vice versa. These functors are inverse on the nose, so the equivalence of categories is strict rather than up to natural isomorphism.
+
+\medskip
+A notable by-product is that the Laplacian operators associated with the two languages become unitarily equivalent under this functorial identification. Thus the ``geometric'' (tunnel) and ``logical'' (proliferation) perspectives are not competing models, but complementary views of a single categorical ontology where locality emerges from refinement dynamics. This PlanetMath entry records the categorical shape of that equivalence for reference within applied and structural category theory.
+
+\bigskip
+\noindent\textbf{Reference.}
+\begin{itemize}
+  \item D. Sukhov, \emph{Tunnel geometry and proliferation logic: a strict categorical equivalence}, arXiv:2601.00803 (2025).
+\end{itemize}
+\end{document}

--- a/18D99-StochasticTapeDiagrams.tex
+++ b/18D99-StochasticTapeDiagrams.tex
@@ -1,0 +1,44 @@
+\documentclass[12pt]{article}
+\usepackage{pmmeta}
+\pmcanonicalname{StochasticTapeDiagrams}
+\pmcreated{2026-02-28 00:29:00}
+\pmmodified{2026-02-28 00:29:00}
+\pmowner{codex}{00000}
+\pmmodifier{codex}{00000}
+\pmtitle{tapes as stochastic matrices of string diagrams}
+\pmrecord{11}{999996}
+\pmprivacy{1}
+\pmauthor{codex}{00000}
+\pmtype{Topic}
+\pmclassification{msc}{18D99}
+\pmdefines{tape diagram}
+\pmdefines{stochastic string diagram}
+\pmdefines{probabilistic Boolean circuit}
+
+\endmetadata
+
+\usepackage{amsmath, amssymb}
+
+\begin{document}
+Tape diagrams extend the usual string-diagram calculus to categories endowed with two monoidal products: a tensor $\otimes$ and a biproduct $\oplus$. They encode how a morphism simultaneously manipulates ``wires'' (the tensor) and distributes across ``branches'' (the biproduct). Bonchi--Cioffo (arXiv:2601.01472) show that, for Kleisli categories of the subdistribution monad, tape diagrams are equivalent to certain stochastic matrices assembled from string diagrams.
+
+\medskip
+\noindent\textbf{Two monoidal structures.} Given a category with a biproduct, one can regard morphisms as matrices whose entries are morphisms between tensor factors. The tape formalism turns this viewpoint into a graphical calculus where horizontal composition records matrix multiplication and vertical stacking records tensoring. When the category is the Kleisli category of the subdistribution monad, each matrix entry is a subdistribution, so tapes describe probabilistic behaviour.
+
+\medskip
+\noindent\textbf{Isomorphism with stochastic matrices.} The main theorem provides an explicit isomorphism between:
+\begin{itemize}
+  \item tapes built in the Kleisli category, and
+  \item stochastic matrices whose entries are subdistributions of ordinary string diagrams.
+\end{itemize}
+Thus every tape is represented uniquely by a stochastic matrix, and conversely every such matrix defines a tape. The authors use this to transport algebraic reasoning (matrix equations) to the string-diagram world where diagrammatic reasoning tools apply.
+
+\medskip
+\noindent\textbf{Probabilistic Boolean circuits.} With the correspondence in place, the paper extracts a complete equational theory for probabilistic Boolean circuits: circuits built out of logical gates but evaluated in subdistributions. Soundness is inherited from the stochastic-matrix semantics, while completeness is proven diagrammatically. The result places probabilistic circuits inside the well-developed theory of monoidal categories with biproducts, making PlanetMath's coverage of string diagrams more useful for probabilistic computing.
+
+\bigskip
+\noindent\textbf{Reference.}
+\begin{itemize}
+  \item F. Bonchi, C.~J. Cioffo, \emph{Tapes as stochastic matrices of string diagrams}, arXiv:2601.01472 (2026).
+\end{itemize}
+\end{document}

--- a/18G55-HomotopyLieRinehartPairs.tex
+++ b/18G55-HomotopyLieRinehartPairs.tex
@@ -1,0 +1,42 @@
+\documentclass[12pt]{article}
+\usepackage{pmmeta}
+\pmcanonicalname{HomotopyLieRinehartPairs}
+\pmcreated{2026-02-28 00:31:00}
+\pmmodified{2026-02-28 00:31:00}
+\pmowner{codex}{00000}
+\pmmodifier{codex}{00000}
+\pmtitle{homotopical algebra of Lie--Rinehart pairs}
+\pmrecord{11}{999996}
+\pmprivacy{1}
+\pmauthor{codex}{00000}
+\pmtype{Topic}
+\pmclassification{msc}{18G55}
+\pmdefines{Lie--Rinehart pair}
+\pmdefines{SH Lie--Rinehart pair}
+\pmdefines{Dwyer--Kan localization}
+
+\endmetadata
+
+\usepackage{amsmath, amssymb}
+
+\begin{document}
+Lie--Rinehart pairs $(A,M)$ generalize Lie algebroids to an algebraic context: the commutative dg algebra $A$ plays the role of functions and the $A$-module $M$ plays the role of derivations, equipped with a Lie bracket compatible with the $A$-structure. Pi\v{s}talo (arXiv:2601.02895) develops a homotopy theory for dg Lie--Rinehart pairs by comparing them with ``strong homotopy'' (SH) versions.
+
+\medskip
+\noindent\textbf{Model via Dwyer--Kan localization.} Consider the category of dg Lie--Rinehart pairs where $A$ is a semi-free cdga over a characteristic-$0$ field and $M$ is built as a cell complex of $A$-modules. Localizing this category at quasi-isomorphisms produces an $\infty$-category of interest. The paper shows that this $\infty$-category is equivalent to the Dwyer--Kan localization of the category of SH Lie--Rinehart pairs satisfying the same cofibrancy conditions. Moreover, the latter forms a category of fibrant objects, so it is amenable to Brown's abstract homotopy theory.
+
+\medskip
+\noindent\textbf{Cofibrations and BV-type resolutions.} SH Lie--Rinehart pairs admit a well-behaved class of cofibrations, which the author exploits to construct functorial factorizations and to prove lifting properties. These tools show uniqueness (up to homotopy) of Batalin--Vilkovisky type resolutions of dg Lie--Rinehart pairs, a key step when transporting structures from derived geometry to higher stacks.
+
+\medskip
+\noindent\textbf{Cartesian fibrations.} Restricting to dg pairs whose underlying cdga is of finite type, and imposing a different cofibrancy hypothesis, the functor $(A,M)\mapsto A$ becomes a Cartesian fibration with presentable fibers. This clarifies how Lie--Rinehart data vary over families of cdgas.
+
+\medskip
+Overall, the paper furnishes a homotopical toolkit for Lie--Rinehart geometry: Dwyer--Kan localization identifies the correct $\infty$-category, SH objects provide manageable fibrant replacements, and cofibration techniques allow explicit constructions inside derived algebraic geometry.
+
+\bigskip
+\noindent\textbf{Reference.}
+\begin{itemize}
+  \item D. Pi\v{s}talo, \emph{Homotopical algebra of Lie-Rinehart pairs}, arXiv:2601.02895 (2026).
+\end{itemize}
+\end{document}

--- a/18G99-HomotopyCoherentCoalgebras.tex
+++ b/18G99-HomotopyCoherentCoalgebras.tex
@@ -1,0 +1,41 @@
+\documentclass[12pt]{article}
+\usepackage{pmmeta}
+\pmcanonicalname{HomotopyCoherentCoalgebras}
+\pmcreated{2026-02-28 00:33:00}
+\pmmodified{2026-02-28 00:33:00}
+\pmowner{codex}{00000}
+\pmmodifier{codex}{00000}
+\pmtitle{point-set models for homotopy coherent coalgebras}
+\pmrecord{11}{999996}
+\pmprivacy{1}
+\pmauthor{codex}{00000}
+\pmtype{Topic}
+\pmclassification{msc}{18G99}
+\pmdefines{homotopy coherent coalgebra}
+\pmdefines{$\infty$-operad coalgebra}
+
+\endmetadata
+
+\usepackage{amsmath, amssymb}
+
+\begin{document}
+Homotopy coherent coalgebras arise when one equips chain complexes with coalgebra structures defined only up to higher coherent homotopies. Roca i Lucio--Petersen--Yalin (arXiv:2601.03101) provide explicit point-set models for such objects by comparing two different $\infty$-categorical descriptions.
+
+\medskip
+\noindent\textbf{Two $\infty$-categories of coalgebras.} On one side they start with differential graded coalgebras over an operad and localize with respect to quasi-isomorphisms, producing an $\infty$-category via Dwyer--Kan localization. On the other they define coalgebras for an enriched $\infty$-operad inside the derived $\infty$-category of chain complexes. The main theorem proves these two $\infty$-categories are equivalent whenever the operad is cofibrant.
+
+\medskip
+\noindent\textbf{Rectification.} The equivalence is obtained inductively by attaching cells and comparing mapping spaces at each stage. It shows that every homotopy coherent coalgebra admits a strict (point-set) representative up to contractible choice. As a result one can work concretely with dg coalgebras without losing higher information.
+
+\medskip
+\noindent\textbf{Examples.} The authors specialize to $E_n$- and $E_\infty$-coalgebras in the derived $\infty$-category of chain complexes over a field, obtaining honest dg models. They also recover an explicit point-set model for the cellular chains functor equipped with its $E_\infty$-coalgebra structure and combine this with work of Bachmann--Burklund to produce algebraic models for nilpotent $p$-adic homotopy types.
+
+\medskip
+These rectification results turn the abstract notion of homotopy coherent coalgebra into something one can compute with: a dg coalgebra whose structure maps and higher coherences are recorded by an enriched operad but whose underlying objects live in an ordinary (point-set) category.
+
+\bigskip
+\noindent\textbf{Reference.}
+\begin{itemize}
+  \item V. Roca i Lucio, D. Petersen, S. Yalin, \emph{Point-set models for homotopy coherent coalgebras}, arXiv:2601.03101 (2026).
+\end{itemize}
+\end{document}


### PR DESCRIPTION
## Summary
- add five new PlanetMath entries covering math.CT arXiv papers 2601.00209, 2601.00803, 2601.01472, 2601.02895, 2601.03101
- document minimal initial functors, tunnel geometry vs proliferation logic, stochastic tapes, Lie--Rinehart homotopy theory, and point-set models for homotopy coherent coalgebras
- follow MSC-prefixed naming convention

## Testing
- not applicable (TeX documentation only)
